### PR TITLE
planet_id column type for session log is wrong

### DIFF
--- a/Core/maps.py
+++ b/Core/maps.py
@@ -2237,7 +2237,7 @@ class PageView(Base):
     full_request = Column(String(255))
     username = Column(String(255))
     session = Column(String(255))
-    planet_id = Column(Integer)
+    planet_id = Column(String(8))
     hostname = Column(String(255))
     request_time = Column(DateTime, default=current_timestamp())
 


### PR DESCRIPTION
Without this patch, the webbie shows internal server error after a user logs in and has his/her own planet set because it tries to write an integer into the the planet_id field (which is now a string) in the session logging table. If you are midround, update DB with

`ALTER TABLE ${alliance}_arthur_log ALTER COLUMN planet_id TYPE character varying(8);`